### PR TITLE
updated argument for _obtain_input_shape

### DIFF
--- a/caption_generator/vgg16.py
+++ b/caption_generator/vgg16.py
@@ -99,7 +99,7 @@ def VGG16(include_top=True, weights='imagenet',
                                       default_size=224,
                                       min_size=48,
                                       data_format=K.image_data_format(),
-                                      include_top=include_top)
+                                      require_flatten=include_top)
 
     if input_tensor is None:
         img_input = Input(shape=input_shape)


### PR DESCRIPTION
To fix error: TypeError: _obtain_input_shape() got an unexpected keyword argument 'include_top'.

Without this change, to use vgg16.py, keras version should be degraded to 2.0.0.